### PR TITLE
posix_acl_chmod takes inode not dentry

### DIFF
--- a/fs/ssdfs/inode.c
+++ b/fs/ssdfs/inode.c
@@ -840,7 +840,7 @@ int ssdfs_setattr(struct user_namespace *mnt_userns,
 
 		if (attr->ia_valid & ATTR_MODE) {
 			err = posix_acl_chmod(&init_user_ns,
-					      dentry, inode->i_mode);
+					      inode, inode->i_mode);
 		}
 	}
 


### PR DESCRIPTION
Fixes build failure with -Werror=incompatible-pointer-types:

fs/ssdfs/inode.c:843:47: error: passing argument 2 of ‘posix_acl_chmod’ from incompatible pointer type